### PR TITLE
Add a Hit Counter

### DIFF
--- a/OriComponent.cs
+++ b/OriComponent.cs
@@ -25,6 +25,8 @@ namespace LiveSplit.OriDE {
         private OriSettings settings;
         private LayoutComponent mapDisplay = null;
         private LayoutComponent energyDisplay = null;
+        private int oldHP = 0;
+        private int hits = 0;
 
         public OriComponent(LiveSplitState state) {
             try {
@@ -68,6 +70,19 @@ namespace LiveSplit.OriDE {
 
             if (settings.RainbowDash && isInGameWorld) {
                 mem.ActivateRainbowDash();
+            }
+
+            if (settings.HitCounter && isInGameWorld)
+            {
+                int currHP = mem.GetCurrentHP();
+
+                if (Model != null && Model.CurrentState.CurrentPhase == TimerPhase.Running && currHP < oldHP)
+                {
+                    hits += 1;
+                    Model.CurrentState.Run.Metadata.SetCustomVariable("hits", hits.ToString());
+                }
+
+                oldHP = currHP;
             }
 
             if (Model != null && currentSplit < settings.Splits.Count) {
@@ -352,6 +367,8 @@ namespace LiveSplit.OriDE {
         public void OnReset(object sender, TimerPhase e) {
             currentSplit = 0;
             ((OriEnergyShardDisplayComponent)energyDisplay.Component).TotalCount = 0;
+            hits = 0;
+            Model.CurrentState.Run.Metadata.SetCustomVariable("hits", hits.ToString());
             WriteLog("---------Reset----------------------------------");
         }
         public void OnResume(object sender, EventArgs e) {
@@ -364,6 +381,8 @@ namespace LiveSplit.OriDE {
             currentSplit++;
             Model.CurrentState.IsGameTimePaused = true;
             ((OriEnergyShardDisplayComponent)energyDisplay.Component).TotalCount = 0;
+            hits = 0;
+            Model.CurrentState.Run.Metadata.SetCustomVariable("hits", hits.ToString());
             WriteLog("---------New Game-------------------------------");
         }
         public void OnUndoSplit(object sender, EventArgs e) {

--- a/Settings/OriSettings.Designer.cs
+++ b/Settings/OriSettings.Designer.cs
@@ -33,6 +33,7 @@
             this.lblSort = new System.Windows.Forms.Label();
             this.rdSortGame = new System.Windows.Forms.RadioButton();
             this.rdSortAlpha = new System.Windows.Forms.RadioButton();
+            this.chkHitCounter = new System.Windows.Forms.CheckBox();
             this.toolTips = new System.Windows.Forms.ToolTip(this.components);
             this.flowMain.SuspendLayout();
             this.flowOptions.SuspendLayout();
@@ -75,6 +76,7 @@
             this.flowOptions.Controls.Add(this.lblSort);
             this.flowOptions.Controls.Add(this.rdSortGame);
             this.flowOptions.Controls.Add(this.rdSortAlpha);
+            this.flowOptions.Controls.Add(this.chkHitCounter);
             this.flowOptions.Location = new System.Drawing.Point(0, 0);
             this.flowOptions.Margin = new System.Windows.Forms.Padding(0);
             this.flowOptions.Name = "flowOptions";
@@ -149,6 +151,18 @@
             this.rdSortAlpha.UseVisualStyleBackColor = true;
             this.rdSortAlpha.CheckedChanged += new System.EventHandler(this.rdSort_CheckedChanged);
             // 
+            // chkHitCounter
+            // 
+            this.chkHitCounter.AutoSize = true;
+            this.chkHitCounter.Location = new System.Drawing.Point(192, 30);
+            this.chkHitCounter.Name = "chkHitCounter";
+            this.chkHitCounter.Size = new System.Drawing.Size(79, 17);
+            this.chkHitCounter.TabIndex = 7;
+            this.chkHitCounter.Text = "Hit Counter";
+            this.toolTips.SetToolTip(this.chkHitCounter, "Counts hits with damage");
+            this.chkHitCounter.UseVisualStyleBackColor = true;
+            this.chkHitCounter.CheckedChanged += new System.EventHandler(this.chkBox_CheckedChanged);
+            // 
             // OriSettings
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -179,6 +193,7 @@
 		private System.Windows.Forms.Label lblSort;
 		private System.Windows.Forms.RadioButton rdSortGame;
 		private System.Windows.Forms.RadioButton rdSortAlpha;
+		private System.Windows.Forms.CheckBox chkHitCounter;
         private System.Windows.Forms.CheckBox chkEnergyShardCount;
     }
 }

--- a/Settings/OriSettings.cs
+++ b/Settings/OriSettings.cs
@@ -10,6 +10,7 @@ namespace LiveSplit.OriDE.Settings {
         public bool ShowMapDisplay { get; set; }
         public bool EnergyShardDisplay { get; set; }
         public bool RainbowDash { get; set; }
+        public bool HitCounter {  get; set; }
         public bool AlphaSort { get; set; }
         private OriComponent component;
         private bool isLoading;
@@ -55,6 +56,7 @@ namespace LiveSplit.OriDE.Settings {
 
             chkShowMapDisplay.Checked = ShowMapDisplay;
             chkRainbowDash.Checked = RainbowDash;
+            chkHitCounter.Checked = HitCounter;
 
             isLoading = false;
             this.flowMain.ResumeLayout(true);
@@ -109,6 +111,7 @@ namespace LiveSplit.OriDE.Settings {
             ShowMapDisplay = chkShowMapDisplay.Checked;
             EnergyShardDisplay = chkEnergyShardCount.Checked;
             RainbowDash = chkRainbowDash.Checked;
+            HitCounter = chkHitCounter.Checked;
         }
         public XmlNode UpdateSettings(XmlDocument document) {
             XmlElement xmlSettings = document.CreateElement("Settings");
@@ -124,6 +127,10 @@ namespace LiveSplit.OriDE.Settings {
             XmlElement xmlDash = document.CreateElement("RainbowDash");
             xmlDash.InnerText = RainbowDash.ToString();
             xmlSettings.AppendChild(xmlDash);
+
+            XmlElement xmlHitCounter = document.CreateElement("HitCounter");
+            xmlHitCounter.InnerText = HitCounter.ToString();
+            xmlSettings.AppendChild(xmlHitCounter);
 
             XmlElement xmlSort = document.CreateElement("AlphaSort");
             xmlSort.InnerText = AlphaSort.ToString();
@@ -168,6 +175,16 @@ namespace LiveSplit.OriDE.Settings {
                 RainbowDash = bool.Parse(showRainbow.InnerText);
             } else {
                 RainbowDash = false;
+            }
+
+            XmlNode countHits = settings.SelectSingleNode(".//HitCounter");
+            if (countHits != null && countHits.InnerText != "")
+            {
+                HitCounter = bool.Parse(countHits.InnerText);
+            }
+            else
+            {
+                HitCounter = false;
             }
 
             XmlNode alphaSort = settings.SelectSingleNode(".//AlphaSort");


### PR DESCRIPTION
Adds a Hit Counter that sets a Custom Variable `hits` to the cumulative hits so far in the current run. Requires LiveSplit version 1.8.30 or later for Custom Variable support.

For local testing, I have a branch with the DLL built here: https://github.com/AlexKnauth/LiveSplit.OriDE/tree/hits-dll